### PR TITLE
Add randomTrack selection test

### DIFF
--- a/app.js
+++ b/app.js
@@ -389,7 +389,7 @@
     }
 
     const randomTrack = () => {
-        const index = Math.floor(getRandomBetween(0, sampleTracks.length - 1));
+        const index = Math.floor(getRandomBetween(0, sampleTracks.length));
         sampleTracks[index].element.click();
         audioPlayer.play();
         onPlayPressed();

--- a/listen-up/app.js
+++ b/listen-up/app.js
@@ -389,7 +389,7 @@
     }
 
     const randomTrack = () => {
-        const index = Math.floor(getRandomBetween(0, sampleTracks.length - 1));
+        const index = Math.floor(getRandomBetween(0, sampleTracks.length));
         sampleTracks[index].element.click();
         audioPlayer.play();
         onPlayPressed();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "auditory-trainer",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/randomTrack.test.js"
+  }
+}

--- a/tests/randomTrack.test.js
+++ b/tests/randomTrack.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+
+// Mimic getRandomBetween and randomTrack from app.js
+const getRandomBetween = (min, max) => Math.random() * (max - min) + min;
+
+const selectedIndices = [];
+
+// Create artificial sampleTracks list with click stubs
+const sampleTracks = Array.from({ length: 5 }, (_, i) => ({
+  element: {
+    click: () => selectedIndices.push(i)
+  }
+}));
+
+// Stub dependencies used in randomTrack
+const audioPlayer = { play: () => {} };
+const onPlayPressed = () => {};
+
+const randomTrack = () => {
+  const index = Math.floor(getRandomBetween(0, sampleTracks.length));
+  sampleTracks[index].element.click();
+  audioPlayer.play();
+  onPlayPressed();
+};
+
+// Call randomTrack multiple times
+for (let i = 0; i < 100; i++) {
+  randomTrack();
+}
+
+// Ensure last entry was selected at least once
+assert(
+  selectedIndices.includes(sampleTracks.length - 1),
+  'Last track was not selected'
+);


### PR DESCRIPTION
## Summary
- add Node-based test verifying randomTrack can select final sample track
- fix randomTrack index calculation to include last entry
- document test run via package.json script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a32b48584832c8c1be4a973f40fa8