### PR TITLE
Fix interval delay comments

### DIFF
--- a/app.js
+++ b/app.js
@@ -290,13 +290,13 @@
 
         // Dynamic filter logic with random interval
         filterInterval = setInterval(() => {
-            const randomDelay = getRandomBetween(100, 3000); // 500ms to 3000ms
+            const randomDelay = getRandomBetween(100, 3000); // 100ms to 3000ms
             setTimeout(dynamicFilterLogic, randomDelay);
         }, 1000);
 
         // Dynamic gating logic with random interval
         gatingInterval = setInterval(() => {
-            const randomDelay = getRandomBetween(200, 4000); // 500ms to 3000ms
+            const randomDelay = getRandomBetween(200, 4000); // 200ms to 4000ms
             setTimeout(dynamicGatingLogic, randomDelay);
         }, 1000);
     }


### PR DESCRIPTION
## Summary
- Correct comments for dynamic filter and gating intervals to match code (100-3000ms and 200-4000ms)

## Testing
- `node --check app.js && echo 'syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_689a32aa78f8832ca0721deeec71a449