### PR TITLE
Include all sample tracks in random selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -389,7 +389,7 @@
     }
 
     const randomTrack = () => {
-        const index = Math.floor(getRandomBetween(0, sampleTracks.length - 1));
+        const index = Math.floor(getRandomBetween(0, sampleTracks.length)); // upper bound is exclusive
         sampleTracks[index].element.click();
         audioPlayer.play();
         onPlayPressed();

--- a/listen-up/app.js
+++ b/listen-up/app.js
@@ -389,7 +389,7 @@
     }
 
     const randomTrack = () => {
-        const index = Math.floor(getRandomBetween(0, sampleTracks.length - 1));
+        const index = Math.floor(getRandomBetween(0, sampleTracks.length)); // upper bound is exclusive
         sampleTracks[index].element.click();
         audioPlayer.play();
         onPlayPressed();


### PR DESCRIPTION
## Summary
- Fix random track selection to include the last sample track and document exclusive upper bound

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node -e "const getRandomBetween=(min,max)=>Math.random()*(max-min)+min; const counts=Array(5).fill(0); for(let i=0;i<10000;i++){const index=Math.floor(getRandomBetween(0,5)); counts[index]++;} console.log(counts);"`


------
https://chatgpt.com/codex/tasks/task_e_689a32a57424832cbbe29c78d7e893c6