### PR TITLE
Fix random track shuffle off-by-one bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -389,7 +389,7 @@
     }
 
     const randomTrack = () => {
-        const index = Math.floor(getRandomBetween(0, sampleTracks.length - 1));
+        const index = Math.floor(getRandomBetween(0, sampleTracks.length));
         sampleTracks[index].element.click();
         audioPlayer.play();
         onPlayPressed();


### PR DESCRIPTION
## Summary
- ensure randomTrack can choose all available sample tracks

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a312cb920832c937349aef8732a46