### PR TITLE
feat: persist audio tracks in IndexedDB

### DIFF
--- a/app.js
+++ b/app.js
@@ -323,7 +323,7 @@
     }
 
     const changeAudio = (file, name) => {
-        const objectURL = file instanceof File ? URL.createObjectURL(file) : file;
+        const objectURL = file instanceof Blob ? URL.createObjectURL(file) : file;
         audioPlayer.src = objectURL;
         document.getElementById('trackLabel').innerText = name;
         audioPlayer.load();
@@ -401,8 +401,15 @@
         playbackSpeedDisplay.innerHTML = `Playback Rate: ${audioPlayer.playbackRate.toFixed(2)}x`;
     });
 
-    audioInput.addEventListener('change', event => {
-        changeAudio(event.target.files[0], event.target.files[0].name);
+    audioInput.addEventListener('change', async event => {
+        const files = event.target.files;
+        if (!files || files.length === 0) return;
+        const metas = await FileManager.addFiles(files);
+        const first = metas[0];
+        if (first) {
+            const blob = await FileManager.getFileBlob(first.id);
+            if (blob) changeAudio(blob, first.name);
+        }
     });
 
     // Event Listeners for updating settings

--- a/file-manager.js
+++ b/file-manager.js
@@ -1,0 +1,26 @@
+(function(global){
+  const STORAGE_KEY = 'userTracks';
+
+  async function addFiles(fileList){
+    const metas = [];
+    const existing = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    for (const file of Array.from(fileList)){
+      const id = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now() + Math.random());
+      await global.IndexedDbUtil.putBlob(id, file);
+      metas.push({ id, name: file.name, type: file.type, size: file.size });
+    }
+    const all = existing.concat(metas);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+    return metas;
+  }
+
+  function getMetadata(){
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  }
+
+  async function getFileBlob(id){
+    return global.IndexedDbUtil.getBlob(id);
+  }
+
+  global.FileManager = { addFiles, getMetadata, getFileBlob };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -662,6 +662,8 @@
     </footer>
 
     <script src="preset.js"></script>
+    <script src="src/db/indexeddb.js"></script>
+    <script src="file-manager.js"></script>
     <script src="app.js"></script>
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>

--- a/listen-up/app.js
+++ b/listen-up/app.js
@@ -247,7 +247,7 @@
     }
 
     const changeAudio = (file, name) => {
-        const objectURL = file instanceof File ? URL.createObjectURL(file) : file;
+        const objectURL = file instanceof Blob ? URL.createObjectURL(file) : file;
         audioPlayer.src = objectURL;
         document.getElementById('trackLabel').innerText = name;
         audioPlayer.load();
@@ -325,8 +325,15 @@
         playbackSpeedDisplay.innerHTML = `Playback Rate: ${audioPlayer.playbackRate.toFixed(2)}x`;
     });
 
-    audioInput.addEventListener('change', event => {
-        changeAudio(event.target.files[0], event.target.files[0].name);
+    audioInput.addEventListener('change', async event => {
+        const files = event.target.files;
+        if (!files || files.length === 0) return;
+        const metas = await FileManager.addFiles(files);
+        const first = metas[0];
+        if (first) {
+            const blob = await FileManager.getFileBlob(first.id);
+            if (blob) changeAudio(blob, first.name);
+        }
     });
 
     // Event Listeners for updating settings

--- a/listen-up/index.html
+++ b/listen-up/index.html
@@ -651,6 +651,8 @@
         </div>
     </footer>
 
+    <script src="../src/db/indexeddb.js"></script>
+    <script src="../file-manager.js"></script>
     <script src="app.js"></script>
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>

--- a/src/db/indexeddb.js
+++ b/src/db/indexeddb.js
@@ -1,0 +1,51 @@
+(function(global){
+  const DB_NAME = 'listenup-files';
+  const DB_VERSION = 1;
+  const STORE_NAME = 'tracks';
+
+  function openDb(){
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async function putBlob(id, blob){
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).put(blob, id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async function getBlob(id){
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const req = tx.objectStore(STORE_NAME).get(id);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function deleteBlob(id){
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  global.IndexedDbUtil = { putBlob, getBlob, deleteBlob };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/src/db/indexeddb.ts
+++ b/src/db/indexeddb.ts
@@ -1,0 +1,52 @@
+const DB_NAME = 'listenup-files';
+const DB_VERSION = 1;
+const STORE_NAME = 'tracks';
+
+export interface TrackBlob {
+  id: string;
+  blob: Blob;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function putBlob(id: string, blob: Blob): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(blob, id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getBlob(id: string): Promise<Blob | undefined> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(id);
+    req.onsuccess = () => resolve(req.result as Blob | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function deleteBlob(id: string): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}


### PR DESCRIPTION
## Summary
- add IndexedDB utility for storing track blobs
- introduce file manager that saves metadata in localStorage and blobs in IndexedDB
- load user audio by fetching blobs from IndexedDB before playback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad07e4cd8832cb13f2ec0680ca0ca