### PR TITLE
Sanitize preset params and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "auditory-trainer",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/randomTrack.test.js && node tests/preset-resolution.spec.js && node tests/range-clamp.spec.js && node tests/indexer-incremental.spec.js"
+    "test": "node tests/randomTrack.test.js && node tests/preset-resolution.spec.js && node tests/range-clamp.spec.js && node tests/indexer-incremental.spec.js && node tests/preset-input.spec.js"
   }
 }

--- a/preset.js
+++ b/preset.js
@@ -3,18 +3,29 @@
 
   const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
-  const clampParams = (p) => ({
-    filterMinHz: clamp(p.filterMinHz, 20, 20000),
-    filterMaxHz: clamp(p.filterMaxHz, 20, 20000),
-    gateMinS: clamp(p.gateMinS, 0.1, 10),
-    gateMaxS: clamp(p.gateMaxS, 0.1, 10),
-    volume: clamp(p.volume, 0, 1),
-    dynamicFilter: !!p.dynamicFilter,
-    dynamicGating: !!p.dynamicGating,
-    dynamicPlayback: !!p.dynamicPlayback,
-    highPassEnabled: p.highPassEnabled !== false,
-    binauralLayering: !!p.binauralLayering,
-  });
+  const toNumber = (value, fallback) => {
+    const num = Number(value);
+    return Number.isNaN(num) ? fallback : num;
+  };
+
+  const clampParams = (p) => {
+    const params = {
+      filterMinHz: clamp(toNumber(p.filterMinHz, 20), 20, 20000),
+      filterMaxHz: clamp(toNumber(p.filterMaxHz, 20000), 20, 20000),
+      gateMinS: clamp(toNumber(p.gateMinS, 0.1), 0.1, 10),
+      gateMaxS: clamp(toNumber(p.gateMaxS, 10), 0.1, 10),
+      volume: clamp(toNumber(p.volume, 1), 0, 1),
+      dynamicFilter: !!p.dynamicFilter,
+      dynamicGating: !!p.dynamicGating,
+      dynamicPlayback: !!p.dynamicPlayback,
+      highPassEnabled: p.highPassEnabled !== false,
+      binauralLayering: !!p.binauralLayering,
+    };
+    if (params.gateMinS > params.gateMaxS) {
+      [params.gateMinS, params.gateMaxS] = [params.gateMaxS, params.gateMinS];
+    }
+    return params;
+  };
 
   const loadPresets = () => {
     try {

--- a/tests/preset-input.spec.js
+++ b/tests/preset-input.spec.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { clampParams } = require('../preset.js');
+
+// NaN values fall back to defaults
+const defaults = clampParams({
+  filterMinHz: NaN,
+  filterMaxHz: NaN,
+  gateMinS: NaN,
+  gateMaxS: NaN,
+  volume: NaN,
+});
+
+assert.strictEqual(defaults.filterMinHz, 20, 'filterMinHz NaN default failed');
+assert.strictEqual(defaults.filterMaxHz, 20000, 'filterMaxHz NaN default failed');
+assert.strictEqual(defaults.gateMinS, 0.1, 'gateMinS NaN default failed');
+assert.strictEqual(defaults.gateMaxS, 10, 'gateMaxS NaN default failed');
+assert.strictEqual(defaults.volume, 1, 'volume NaN default failed');
+
+// Inverted gating range should be swapped
+const swapped = clampParams({ gateMinS: 8, gateMaxS: 2 });
+assert.strictEqual(swapped.gateMinS, 2, 'gateMinS not swapped');
+assert.strictEqual(swapped.gateMaxS, 8, 'gateMaxS not swapped');


### PR DESCRIPTION
## Summary
- Sanitize preset parameter inputs using `Number()` with fallbacks
- Ensure gating range respects min/max order
- Add tests for NaN inputs and inverted gating ranges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad3896ebc832caf4785c87dbec6ac