### PR TITLE
Use relative path for tracklist fetch

### DIFF
--- a/app.js
+++ b/app.js
@@ -443,7 +443,7 @@
 
     const fetchSampleTracks = () => {
 
-        fetch('/music/tracklist.json')
+        fetch('./music/tracklist.json')
             .then(response => response.json())
             .then(data => {
 


### PR DESCRIPTION
## Summary
- use a relative path when fetching the music tracklist so the app works from nested URLs

## Testing
- `curl -I http://localhost:8000/music/tracklist.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad523c5ec832c9707c56fbec38607