### PR TITLE
chore: set capacitor web directory

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,10 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'auditory.trainer',
+  appName: 'Auditory Trainer',
+  webDir: 'listen-up',
+  bundledWebRuntime: false,
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add capacitor config with webDir pointing to built web assets

## Testing
- `npx cap copy`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af90cc274832ca924b25b6577ad53