### PR TITLE
docs: add building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,27 @@
 
 Whether you're looking to improve your language comprehension skills, refine your musical ear, or undergo auditory therapy, ListenUp provides a versatile and customizable environment to help you reach your goals.
 
+## Building
+
+### Prerequisites
+
+- **Node.js** and **npm**
+- **Electron**
+- **Java Development Kit (JDK)** and **Android SDK** for mobile builds
+
+### Commands
+
+To create a portable Windows release:
+
+```bash
+npm run build:win
+```
+
+To assemble an Android release APK:
+
+```bash
+npm run build:android
+```
+
+Android releases must be signed. Generate a keystore with `keytool` and supply its path and credentials via a `keystore.properties` or `gradle.properties` file before building.
+


### PR DESCRIPTION
## Summary
- document build prerequisites for Node.js, Electron, and Android SDK
- add build commands for Windows and Android with keystore signing notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afb376638832caee5b26142c05362