### PR TITLE
chore: point capacitor to root web dir

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,7 @@ import { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'auditory.trainer',
   appName: 'Auditory Trainer',
-  webDir: 'listen-up',
+  webDir: '.',
   bundledWebRuntime: false,
 };
 


### PR DESCRIPTION
## Summary
- point Capacitor's webDir to the repository root

## Testing
- `npm test`
- `npx cap sync android` *(fails: "." is not a valid value for webDir)*
- `cd android && ./gradlew assembleRelease` *(fails: could not read capacitor.settings.gradle)*

------
https://chatgpt.com/codex/tasks/task_e_689b1a3f014c832c8e063b24ab713ea1