### PR TITLE
Configure Android dependency without committed platform files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ promo/
 .DS_Store
 
 # Build directories
-android/
 ios/
+android/
 build/
 platforms/
 node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "auditory-trainer",
       "version": "1.0.0",
       "devDependencies": {
+        "@capacitor/android": "^7.4.2",
         "@capacitor/cli": "^7.4.2",
         "@capacitor/core": "^7.4.2",
         "electron": "^37.2.6",
@@ -542,6 +543,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@capacitor/android": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-7.4.2.tgz",
+      "integrity": "sha512-FZ7M9NwFkljR7EP5eXiE32mAIfZNcYw2CzRMCG3rQu0u0ZaIoeOeq5/oK4YcDnGpNmu8jpngKJqZ+9OiSQSwDg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^7.4.0"
+      }
     },
     "node_modules/@capacitor/cli": {
       "version": "7.4.2",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "build": "npm run compile:db"
   },
   "devDependencies": {
+    "@capacitor/android": "^7.4.2",
     "@capacitor/cli": "^7.4.2",
     "@capacitor/core": "^7.4.2",
     "electron": "^37.2.6",
     "electron-builder": "^26.0.12",
-    "typescript": "^5.9.2",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "typescript": "^5.9.2"
   },
   "type": "module",
   "jest": {


### PR DESCRIPTION
## Summary
- remove Android platform directory to avoid tracking generated binaries
- ignore `android/` in version control while retaining Android development dependencies

## Testing
- `npm run build`
- `npx cap sync android`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b29d9e10c832cb3a3728ad258cdb1