### PR TITLE
Persist FFP parameters in presets

### DIFF
--- a/dist/preset.js
+++ b/dist/preset.js
@@ -20,6 +20,22 @@
       dynamicPlayback: !!p.dynamicPlayback,
       highPassEnabled: p.highPassEnabled !== false,
       binauralLayering: !!p.binauralLayering,
+      ffp: {
+        preGain: clamp(toNumber(p.ffp?.preGain, 1), 0, 2),
+        lowShelfFreq: clamp(toNumber(p.ffp?.lowShelfFreq, 200), 20, 1000),
+        lowShelfGain: clamp(toNumber(p.ffp?.lowShelfGain, 0), -15, 15),
+        peaking1Freq: clamp(toNumber(p.ffp?.peaking1Freq, 500), 200, 2000),
+        peaking1Gain: clamp(toNumber(p.ffp?.peaking1Gain, 0), -15, 15),
+        peaking2Freq: clamp(toNumber(p.ffp?.peaking2Freq, 3000), 1000, 6000),
+        peaking2Gain: clamp(toNumber(p.ffp?.peaking2Gain, 0), -15, 15),
+        highShelfFreq: clamp(toNumber(p.ffp?.highShelfFreq, 6000), 2000, 12000),
+        highShelfGain: clamp(toNumber(p.ffp?.highShelfGain, 0), -15, 15),
+        tiltFreq: clamp(toNumber(p.ffp?.tiltFreq, 1000), 20, 20000),
+        tiltGain: clamp(toNumber(p.ffp?.tiltGain, 0), -15, 15),
+        modRate: clamp(toNumber(p.ffp?.modRate, 0), 0, 10),
+        modDepth: clamp(toNumber(p.ffp?.modDepth, 0), 0, 1),
+        modMode: ['off', 'sine', 'triangle'].includes(p.ffp?.modMode) ? p.ffp.modMode : 'off',
+      },
     };
     if (params.gateMinS > params.gateMaxS) {
       [params.gateMinS, params.gateMaxS] = [params.gateMaxS, params.gateMinS];
@@ -29,7 +45,14 @@
 
   const loadPresets = () => {
     try {
-      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      const presets = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      return presets.map(p => {
+        if (p.params) {
+          p.params = clampParams(p.params);
+          return p;
+        }
+        return { ...p, params: clampParams(p) };
+      });
     } catch (_) {
       return [];
     }

--- a/dist/uiControls.js
+++ b/dist/uiControls.js
@@ -112,6 +112,7 @@ export function initControls() {
         dynamicGating.checked = p.dynamicGating;
         dynamicPlaybackRate.checked = p.dynamicPlayback;
         dynamicBinauralBeat.checked = p.binauralLayering;
+        applyFfpPreset(p.ffp || {});
         updateSettings();
         engine.dynamicPlaybackLogic();
         engine.dynamicBinauralBeatLogic();
@@ -182,7 +183,8 @@ export function initControls() {
             dynamicFilter: dynamicFilter.checked,
             dynamicGating: dynamicGating.checked,
             dynamicPlayback: dynamicPlaybackRate.checked,
-            binauralLayering: dynamicBinauralBeat.checked
+            binauralLayering: dynamicBinauralBeat.checked,
+            ffp: getFfpParams(),
         });
         const idx = presets.findIndex(p => p.name === name);
         if (idx >= 0) {


### PR DESCRIPTION
## Summary
- support FFP EQ parameters in preset clamping with proper bounds
- migrate existing presets and persist new `ffp` namespace
- load/save UI presets with bundled FFP settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab2e0b688832cae9a77f7c4c3187e