### PR TITLE
Add tests for FFP filter and presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "type": "module",
   "jest": {
     "testMatch": [
-      "**/tests/audioEngine.test.js"
+      "**/tests/**/*.test.js"
     ]
   }
 }

--- a/tests/ffpFilter.test.js
+++ b/tests/ffpFilter.test.js
@@ -1,0 +1,65 @@
+import { createFfpChain } from '../dist/ffpFilter.js';
+
+class MockNode {
+  constructor(name) {
+    this.name = name;
+    this.connections = [];
+    this.gain = { value: 0 };
+    this.frequency = { value: 0 };
+    this.Q = { value: 0 };
+    this.threshold = { value: 0 };
+    this.knee = { value: 0 };
+    this.ratio = { value: 0 };
+    this.attack = { value: 0 };
+    this.release = { value: 0 };
+  }
+  connect(node) {
+    this.connections.push(node);
+  }
+  disconnect() {
+    this.connections = [];
+  }
+}
+
+class MockContext {
+  constructor() {
+    this.created = [];
+  }
+  createGain() {
+    const node = new MockNode('gain');
+    this.created.push(node);
+    return node;
+  }
+  createBiquadFilter() {
+    const node = new MockNode('biquad');
+    this.created.push(node);
+    return node;
+  }
+  createDynamicsCompressor() {
+    const node = new MockNode('compressor');
+    this.created.push(node);
+    return node;
+  }
+}
+
+test('builds node chain and toggles bypass', () => {
+  const ctx = new MockContext();
+  const input = new MockNode('input');
+  const chain = createFfpChain(ctx, input, { tiltFreq: 1000, tiltGain: 1 });
+  const [preGain, lowShelf, peaking1, peaking2, highShelf, tilt, limiter] = ctx.created;
+
+  expect(input.connections).toEqual([preGain]);
+  expect(preGain.connections).toEqual([lowShelf]);
+  expect(lowShelf.connections).toEqual([peaking1]);
+  expect(peaking1.connections).toEqual([peaking2]);
+  expect(peaking2.connections).toEqual([highShelf]);
+  expect(highShelf.connections).toEqual([tilt]);
+  expect(tilt.connections).toEqual([limiter]);
+  expect(chain.output).toBe(limiter);
+
+  chain.bypass(true);
+  expect(input.connections).toEqual([limiter]);
+
+  chain.bypass(false);
+  expect(input.connections).toEqual([preGain]);
+});

--- a/tests/ffpPreset.test.js
+++ b/tests/ffpPreset.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import vm from 'vm';
+import { loadPresets, savePresets } from '../dist/ffpPresets.js';
+
+global.window = {};
+const code = fs.readFileSync(new URL('../dist/preset.js', import.meta.url), 'utf8');
+const sandbox = { module: { exports: {} }, window: global.window };
+vm.runInNewContext(code, sandbox);
+const { clampParams } = sandbox.module.exports;
+
+describe('clampParams ffp limits', () => {
+  test('clamps values to allowed ranges', () => {
+    const clamped = clampParams({
+      ffp: {
+        preGain: 5,
+        lowShelfFreq: 0,
+        lowShelfGain: -50,
+        peaking1Freq: 50,
+        peaking1Gain: 50,
+        peaking2Freq: 10000,
+        peaking2Gain: -50,
+        highShelfFreq: 50000,
+        highShelfGain: 50,
+        tiltFreq: 50000,
+        tiltGain: -50,
+        modRate: 20,
+        modDepth: 2,
+        modMode: 'weird'
+      }
+    }).ffp;
+    expect(clamped.preGain).toBe(2);
+    expect(clamped.lowShelfFreq).toBe(20);
+    expect(clamped.lowShelfGain).toBe(-15);
+    expect(clamped.peaking1Freq).toBe(200);
+    expect(clamped.peaking1Gain).toBe(15);
+    expect(clamped.peaking2Freq).toBe(6000);
+    expect(clamped.peaking2Gain).toBe(-15);
+    expect(clamped.highShelfFreq).toBe(12000);
+    expect(clamped.highShelfGain).toBe(15);
+    expect(clamped.tiltFreq).toBe(20000);
+    expect(clamped.tiltGain).toBe(-15);
+    expect(clamped.modRate).toBe(10);
+    expect(clamped.modDepth).toBe(1);
+    expect(clamped.modMode).toBe('off');
+  });
+});
+
+describe('FFP preset save/load', () => {
+  test('performs roundtrip through storage', () => {
+    const store = {};
+    global.localStorage = {
+      getItem: jest.fn(key => (key in store ? store[key] : null)),
+      setItem: jest.fn((key, value) => { store[key] = value; })
+    };
+    global.window.ListenUpPresets = { clampParams };
+
+    const preset = { name: 'test', params: { preGain: 1.5, lowShelfFreq: 250 } };
+    savePresets([preset]);
+    const loaded = loadPresets();
+    const expected = { name: 'test', params: clampParams({ ffp: preset.params }).ffp };
+    expect(loaded).toEqual([expected]);
+  });
+});

--- a/tests/randomTrack.test.js
+++ b/tests/randomTrack.test.js
@@ -1,35 +1,31 @@
-const assert = require('assert');
-
 // Mimic getRandomBetween and randomTrack from app.js
 const getRandomBetween = (min, max) => Math.random() * (max - min) + min;
 
-const selectedIndices = [];
+test('randomTrack selects last index at least once', () => {
+  const selectedIndices = [];
 
-// Create artificial sampleTracks list with click stubs
-const sampleTracks = Array.from({ length: 5 }, (_, i) => ({
-  element: {
-    click: () => selectedIndices.push(i)
+  // Create artificial sampleTracks list with click stubs
+  const sampleTracks = Array.from({ length: 5 }, (_, i) => ({
+    element: {
+      click: () => selectedIndices.push(i)
+    }
+  }));
+
+  // Stub dependencies used in randomTrack
+  const audioPlayer = { play: () => {} };
+  const onPlayPressed = () => {};
+
+  const randomTrack = () => {
+    const index = Math.floor(getRandomBetween(0, sampleTracks.length));
+    sampleTracks[index].element.click();
+    audioPlayer.play();
+    onPlayPressed();
+  };
+
+  // Call randomTrack multiple times
+  for (let i = 0; i < 100; i++) {
+    randomTrack();
   }
-}));
 
-// Stub dependencies used in randomTrack
-const audioPlayer = { play: () => {} };
-const onPlayPressed = () => {};
-
-const randomTrack = () => {
-  const index = Math.floor(getRandomBetween(0, sampleTracks.length));
-  sampleTracks[index].element.click();
-  audioPlayer.play();
-  onPlayPressed();
-};
-
-// Call randomTrack multiple times
-for (let i = 0; i < 100; i++) {
-  randomTrack();
-}
-
-// Ensure last entry was selected at least once
-assert(
-  selectedIndices.includes(sampleTracks.length - 1),
-  'Last track was not selected'
-);
+  expect(selectedIndices).toContain(sampleTracks.length - 1);
+});


### PR DESCRIPTION
## Summary
- add Jest test for FFP WebAudio filter chain and bypass
- add FFP preset clamp and save/load roundtrip tests
- expand Jest config and align existing random track test with Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaba8cd714832c9c327574599b2a21