### PR TITLE
Expand audio player area

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -336,7 +336,7 @@
             </div>
         </div>
         <div class="row justify-content-center mt-4">
-            <div class="col-12 col-md-6">
+            <div class="col-12 col-md-8">
                 <div class="d-flex align-items-center">
                     <!-- Audio Player -->
                     <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled></audio>

--- a/dist/main.css
+++ b/dist/main.css
@@ -188,3 +188,7 @@ button.small {
 .ffp-section h6 {
   margin-top: 0.8em;
 }
+
+#audioPlayer {
+  width: 100%;
+}

--- a/listen-up/index.html
+++ b/listen-up/index.html
@@ -332,7 +332,7 @@
             </div>
         </div>
         <div class="row justify-content-center mt-4">
-            <div class="col-12 col-md-6">
+            <div class="col-12 col-md-8">
                 <div class="d-flex align-items-center">
                     <!-- Audio Player -->
                     <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled>

--- a/listen-up/main.css
+++ b/listen-up/main.css
@@ -178,3 +178,7 @@ button.small {
 .bg-primary {
   background-color: #0074cc !important;
 }
+
+#audioPlayer {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- widen audio player column in both builds
- ensure audio element spans full available width with explicit CSS rule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad9789868832c854bbf4d56485021