### PR TITLE
Remove sample track library and default audio

### DIFF
--- a/listen-up/app.js
+++ b/listen-up/app.js
@@ -24,7 +24,6 @@
     let currentVolume = 1;
     let ramp = .15;
     let panningRamp = .45;
-    let sampleTracks = [];
 
     // JavaScript Audio Context
     let audioContext;
@@ -365,45 +364,7 @@
         stopBinauralBeats();
     });
 
-    const fetchSampleTracks = () => {
-
-        fetch('/music/tracklist.json')
-            .then(response => response.json())
-            .then(data => {
-
-                const trackList = document.getElementById('sampleTrackList');
-                trackList.innerHTML = '';
-                data.forEach(track => {
-                    const listItem = document.createElement('li');
-                    const label = track.name + " (" + track.artist_name + ")";
-                    listItem.textContent = label;
-                    listItem.addEventListener('click', function () {
-                        changeAudio(track.audio, label);
-                        $('#sampleTrackModal').modal('hide');
-                    });
-                    trackList.appendChild(listItem);
-                    track.element = listItem;
-                });
-                sampleTracks = data;
-
-            })
-            .catch(error => console.error('Error fetching sample tracks:', error));
-
-        document.getElementById('trackPickerBtn').addEventListener('click', function (evt) {
-            evt.preventDefault();
-            $('#sampleTrackModal').modal('show');
-        });
-    }
-
-    const randomTrack = () => {
-        const index = Math.floor(getRandomBetween(0, sampleTracks.length));
-        sampleTracks[index].element.click();
-        audioPlayer.play();
-        onPlayPressed();
-    }
-
     window.addEventListener('DOMContentLoaded', () => {
-        fetchSampleTracks();
         window.addEventListener('click', firstInteractionListener);
 
         shuffleBtn.addEventListener("click", function () {
@@ -418,8 +379,5 @@
             }
         });
 
-        audioPlayer.addEventListener("ended", function () {
-            if (settings.shuffle) randomTrack();
-        });
     })
 })();

--- a/listen-up/index.html
+++ b/listen-up/index.html
@@ -303,10 +303,10 @@
             </div>
         </div>
         <div class="row justify-content-center no-gutters">
-            <div class="col-6 col-md-3 d-flex">
+            <div class="col-12 col-md-6 d-flex">
 
                 <!-- Pick from Device -->
-                <div class="input-group mb-3 flex-grow-1 mr-2">
+                <div class="input-group mb-3 flex-grow-1">
                     <div class="custom-file">
                         <input type="file" class="custom-file-input" id="audioInput" accept="audio/*">
                         <label class="custom-file-label" for="audioInput">Choose a file</label>
@@ -315,16 +315,11 @@
 
 
             </div>
-            <div class="col-6 col-md-3 d-flex">
-                <!-- Pick from Library -->
-                <button id="trackPickerBtn" class="btn btn-primary mb-3 flex-grow-1 ml-2" style="flex-basis: 0;">Free
-                    Library 🎧</button>
-            </div>
         </div>
 
         <div class="row justify-content-center mt-2">
             <div class="col-12 col-md-6 d-flex justify-content-between align-items-center">
-                <div id="trackLabel">J.S. Bach - Cello Suite No. 1: Prelude</div>
+                <div id="trackLabel">No track selected</div>
                 <div class="alert alert-info mb-0 py-1 px-2" role="alert" id="playbackSpeedDisplay"
                     style="font-size: 0.8rem;">
                     Playback Rate: 1.00x
@@ -335,9 +330,7 @@
             <div class="col-12 col-md-8">
                 <div class="d-flex align-items-center">
                     <!-- Audio Player -->
-                    <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled>
-                        <source src="./music/bach-cello-suite-1-prelude.mp3">
-                    </audio>
+                    <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled></audio>
                     <!-- Shuffle Button -->
                     <button id="shuffleBtn" class="btn btn-success ms-2 margin-left">Shuffle</button>
                 </div>
@@ -526,21 +519,6 @@
                     <button type="submit" class="btn btn-primary">Submit</button>
                 </div>
                 </form>
-            </div>
-        </div>
-    </div>
-
-    <!-- Sample Library Modal -->
-    <div id="sampleTrackModal" class="modal fade">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Sample Music Library 🎧</h5>
-                    <button type="button" class="close" data-dismiss="modal">&times;</button>
-                </div>
-                <div class="modal-body">
-                    <ul id="sampleTrackList"></ul>       
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- drop Free Library UI and sample track modal
- default player shows "No track selected" with no preloaded audio
- purge sample track fetching and modal logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab16353e9c832c952fae3d95793042