### PR TITLE
Remove shuffle controls and expand audio player

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -337,12 +337,8 @@
         </div>
         <div class="row justify-content-center mt-4">
             <div class="col-12 col-md-6">
-                <div class="d-flex align-items-center">
-                    <!-- Audio Player -->
-                    <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled></audio>
-                    <!-- Shuffle Button -->
-                    <button id="shuffleBtn" class="btn btn-success ms-2 margin-left">Shuffle</button>
-                </div>
+                <!-- Audio Player -->
+                <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled></audio>
             </div>
         </div>
 

--- a/dist/uiControls.js
+++ b/dist/uiControls.js
@@ -75,8 +75,7 @@ export function initControls() {
         dynamicFilter: dynamicFilter.checked,
         dynamicGating: dynamicGating.checked,
         dynamicPlaybackRate: dynamicPlaybackRate.checked,
-        dynamicBinauralBeat: dynamicBinauralBeat.checked,
-        shuffle: true
+        dynamicBinauralBeat: dynamicBinauralBeat.checked
     };
 
     const engine = new AudioEngine(audioPlayer, settings);

--- a/listen-up/app.js
+++ b/listen-up/app.js
@@ -24,7 +24,6 @@
     let currentVolume = 1;
     let ramp = .15;
     let panningRamp = .45;
-    let sampleTracks = [];
 
     // JavaScript Audio Context
     let audioContext;
@@ -42,7 +41,6 @@
     const dynamicGating = document.getElementById('dynamicGating');
     const dynamicPlaybackRate = document.getElementById('dynamicPlaybackRate');
     const dynamicBinauralBeat = document.getElementById('dynamicBinauralBeat');
-    const shuffleBtn = document.getElementById("shuffleBtn");
 
     // Audio Nodes
     let sourceNode;
@@ -72,8 +70,7 @@
         dynamicFilter: dynamicFilter.checked,
         dynamicGating: dynamicGating.checked,
         dynamicPlaybackRate: dynamicPlaybackRate.checked,
-        dynamicBinauralBeat: dynamicBinauralBeat.checked,
-        shuffle: true
+        dynamicBinauralBeat: dynamicBinauralBeat.checked
     };
 
     // Initialize Audio Nodes and connect them
@@ -382,9 +379,7 @@
                         $('#sampleTrackModal').modal('hide');
                     });
                     trackList.appendChild(listItem);
-                    track.element = listItem;
                 });
-                sampleTracks = data;
 
             })
             .catch(error => console.error('Error fetching sample tracks:', error));
@@ -395,31 +390,8 @@
         });
     }
 
-    const randomTrack = () => {
-        const index = Math.floor(getRandomBetween(0, sampleTracks.length));
-        sampleTracks[index].element.click();
-        audioPlayer.play();
-        onPlayPressed();
-    }
-
     window.addEventListener('DOMContentLoaded', () => {
         fetchSampleTracks();
         window.addEventListener('click', firstInteractionListener);
-
-        shuffleBtn.addEventListener("click", function () {
-            if (this.classList.contains("btn-secondary")) {
-                this.classList.remove("btn-secondary");
-                this.classList.add("btn-success");
-                settings.shuffle = true;
-            } else {
-                this.classList.remove("btn-success");
-                this.classList.add("btn-secondary");
-                settings.shuffle = false;
-            }
-        });
-
-        audioPlayer.addEventListener("ended", function () {
-            if (settings.shuffle) randomTrack();
-        });
     })
 })();

--- a/listen-up/index.html
+++ b/listen-up/index.html
@@ -333,14 +333,10 @@
         </div>
         <div class="row justify-content-center mt-4">
             <div class="col-12 col-md-6">
-                <div class="d-flex align-items-center">
-                    <!-- Audio Player -->
-                    <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled>
-                        <source src="./music/bach-cello-suite-1-prelude.mp3">
-                    </audio>
-                    <!-- Shuffle Button -->
-                    <button id="shuffleBtn" class="btn btn-success ms-2 margin-left">Shuffle</button>
-                </div>
+                <!-- Audio Player -->
+                <audio id="audioPlayer" class="w-100" crossOrigin="anonymous" controls disabled>
+                    <source src="./music/bach-cello-suite-1-prelude.mp3">
+                </audio>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- remove shuffle button from web and app pages, letting audio player fill available space
- drop shuffle setting and random track logic from scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad7c4088c832c866e01c6a31c6e73